### PR TITLE
Added a sniffer for the PORT environment variable. This cleans up the…

### DIFF
--- a/src/SteelToe.Extensions.Configuration.CloudFoundry/CloudFoundryHostBuilderExtensions.cs
+++ b/src/SteelToe.Extensions.Configuration.CloudFoundry/CloudFoundryHostBuilderExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+
+namespace SteelToe.Extensions.Configuration.CloudFoundry
+{
+    public static class CloudFoundryHostBuilderExtensions
+    {
+        public static IWebHostBuilder UseCloudFoundryHosting(this IWebHostBuilder webHostBuilder)
+        {
+            if(webHostBuilder == null)
+            {
+                throw new ArgumentNullException(nameof(webHostBuilder));
+            }
+
+            List<string> urls = new List<string>();
+
+            string portStr = Environment.GetEnvironmentVariable("PORT");
+            if (!string.IsNullOrWhiteSpace(portStr))
+            {
+                int port;
+                if (int.TryParse(portStr, out port))
+                {
+                    urls.Add($"http://*:{port}");
+                }
+            }
+
+            if (urls.Count > 0)
+            {
+                webHostBuilder.UseUrls(urls.ToArray());
+            }
+
+            return webHostBuilder;
+        }
+    }
+}

--- a/src/SteelToe.Extensions.Configuration.CloudFoundry/project.json
+++ b/src/SteelToe.Extensions.Configuration.CloudFoundry/project.json
@@ -33,6 +33,7 @@
     "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
     "Microsoft.Extensions.Options": "1.0.0",
     "Microsoft.Extensions.Options.ConfigurationExtensions": "1.0.0",
-    "Newtonsoft.Json": "9.0.1"
+    "Newtonsoft.Json": "9.0.1",
+    "Microsoft.AspNetCore.Hosting.Abstractions": "1.0.0"
   }
 }

--- a/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryHostBuilderExtensionsTest.cs
+++ b/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryHostBuilderExtensionsTest.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SteelToe.Extensions.Configuration.CloudFoundry.Test
+{
+    public class CloudFoundryHostBuilderExtensionsTest
+    {
+
+        [Fact]
+        public void AddCloudFoundry_ThrowsIfHostBuilderNull()
+        {
+            // Arrange
+            IWebHostBuilder webHostBuilder = null;
+
+            // Act and Assert
+            var ex = Assert.Throws<ArgumentNullException>(() => CloudFoundryHostBuilderExtensions.UseCloudFoundryHosting(webHostBuilder));
+            Assert.Contains(nameof(webHostBuilder), ex.Message);
+        }
+
+        [Fact]
+        public void AddCloudFoundry_DoNotSetUrlsIfNull()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("PORT", null);
+            var hostBuilder = new WebHostBuilder()
+                                .UseStartup<TestServerStartup>()
+                                .UseKestrel();
+
+            // Act and Assert
+            hostBuilder.UseCloudFoundryHosting();
+            using (hostBuilder.Build())
+            {
+                //No-Op
+            }
+        }
+
+        [Fact]
+        public void AddCloudFoundry_MakeSureThePortIsSet()
+        {
+            // Arrange
+            Environment.SetEnvironmentVariable("PORT", "42");
+            var hostBuilder = new WebHostBuilder()
+                                .UseStartup<TestServerStartup42>()
+                                .UseKestrel();
+
+            // Act and Assert
+            hostBuilder.UseCloudFoundryHosting();
+            using (hostBuilder.Build())
+            {
+                //No-Op
+            }
+
+        }
+    }
+}

--- a/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/TestServerStartup.cs
+++ b/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/TestServerStartup.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace SteelToe.Extensions.Configuration.CloudFoundry.Test
+{
+    public class TestServerStartup
+    {
+        public List<string> ExpectedAddresses = new List<string>();
+
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddMvc();
+        }
+
+        public void Configure(IApplicationBuilder app)
+        {
+            var addresses = ExpectedAddresses.DefaultIfEmpty("http://localhost:5000");
+            Assert.Equal(addresses, app.ServerFeatures.Get<IServerAddressesFeature>()?.Addresses);
+            app.UseMvc();
+        }
+    }
+}

--- a/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/TestServerStartup42.cs
+++ b/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/TestServerStartup42.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace SteelToe.Extensions.Configuration.CloudFoundry.Test
+{
+    public class TestServerStartup42 : TestServerStartup
+    {
+        public TestServerStartup42()
+        {
+            this.ExpectedAddresses.Add("http://*:42");
+        }
+    }
+}

--- a/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/project.json
+++ b/test/SteelToe.Extensions.Configuration.CloudFoundry.Test/project.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "version": "1.0.0",
   "testRunner": "xunit",
   "description": "Unit test project for SteelToe.Extensions.Configuration.CloudFoundry",
@@ -39,7 +39,8 @@
     "Microsoft.Extensions.Options": "1.0.0",
     "SteelToe.Extensions.Configuration.CloudFoundry": "1.0.0-*",
     "xunit": "2.2.0-beta2-build3300",
-    "dotnet-test-xunit": "2.2.0-preview2-build1029"
+    "dotnet-test-xunit": "2.2.0-preview2-build1029",
+    "Microsoft.AspNetCore.Server.Kestrel": "1.0.1"
   },
   "buildOptions": {
     "copyToOutput": {


### PR DESCRIPTION
… need to do the following:

```
    public static void Main(string[] args)
    {
        var host = new WebHostBuilder()
            .UseKestrel()
            .UseUrls(GetServerUrls(args))
            .UseContentRoot(Directory.GetCurrentDirectory())
            .UseIISIntegration()
            .UseStartup<Startup>()
            .Build();

        host.Run();
    }
    private static string[] GetServerUrls(string[] args)
    {
        List<string> urls = new List<string>();
        for (int i = 0; i < args.Length; i++)
        {
            if ("--server.urls".Equals(args[i], StringComparison.OrdinalIgnoreCase))
            {
                urls.Add(args[i + 1]);
            }
        }
        return urls.ToArray();
    }
```

---

 And simplifies it to just this:

```
    public static void Main(string[] args)
    {
        var host = new WebHostBuilder()
            .UseKestrel()
            .UseCloudFoundryHosting() // Added
            .UseContentRoot(Directory.GetCurrentDirectory())
            .UseIISIntegration()
            .UseStartup<Startup>()
            .Build();

        host.Run();
    }
```

It also make it so that the manifest.yml files are not poluted with values like the following:

  command: ./MusicStoreUI --server.urls http://*:%PORT%

and reduce it to:

  command: ./MusicStoreUI
