### PR TITLE
Enable VCAP environment to be testable

### DIFF
--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationBuilderExtensions.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationBuilderExtensions.cs
@@ -24,13 +24,17 @@ namespace Steeltoe.Extensions.Configuration
     {
         public static IConfigurationBuilder AddCloudFoundry(this IConfigurationBuilder configurationBuilder)
         {
+            return configurationBuilder.AddCloudFoundry(null);
+        }
+
+        public static IConfigurationBuilder AddCloudFoundry(this IConfigurationBuilder configurationBuilder, ICloudFoundrySettingsReader settingsReader)
+        {
             if (configurationBuilder == null)
             {
                 throw new ArgumentNullException(nameof(configurationBuilder));
             }
 
-            configurationBuilder.Add(new CloudFoundryConfigurationSource());
-            return configurationBuilder;
+            return configurationBuilder.Add(new CloudFoundryConfigurationSource { SettingsReader = settingsReader });
         }
     }
 }

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationProvider.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationProvider.cs
@@ -24,7 +24,7 @@ using Microsoft.Extensions.Configuration.Json;
 
 namespace Steeltoe.Extensions.Configuration.CloudFoundry
 {
-    public class CloudFoundryConfigurationProvider : ConfigurationProvider, IConfigurationSource
+    public class CloudFoundryConfigurationProvider : ConfigurationProvider
     {
         private const string VCAP_PREFIX = "VCAP_";
         private const string APPLICATION = "APPLICATION";
@@ -39,6 +39,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
         public CloudFoundryConfigurationProvider()
         {
         }
+
         public override void Load()
         {
             var builder = new ConfigurationBuilder();
@@ -140,11 +141,6 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
             if (string.IsNullOrEmpty(section.Value))
                 return;
             Data[prefix + ConfigurationPath.KeyDelimiter + section.Path] = section.Value;
-        }
-
-        public IConfigurationProvider Build(IConfigurationBuilder builder)
-        {
-            return this;
         }
 
         internal static MemoryStream GetMemoryStream(string json)

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationProvider.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationProvider.cs
@@ -26,31 +26,26 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
 {
     public class CloudFoundryConfigurationProvider : ConfigurationProvider
     {
-        private const string VCAP_PREFIX = "VCAP_";
-        private const string APPLICATION = "APPLICATION";
-        private const string SERVICES = "SERVICES";
+        private readonly ICloudFoundrySettingsReader _settingsReader;
 
-        private const string CF_INSTANCE_GUID = "CF_INSTANCE_GUID";
-        private const string CF_INSTANCE_INDEX = "CF_INSTANCE_INDEX";
-        private const string CF_INSTANCE_PORT = "CF_INSTANCE_PORT";
-        private const string CF_INSTANCE_IP = "CF_INSTANCE_IP";
-        private const string CF_INSTANCE_INTERNAL_IP = "CF_INSTANCE_INTERNAL_IP";
-
-        public CloudFoundryConfigurationProvider()
+        public CloudFoundryConfigurationProvider(ICloudFoundrySettingsReader settingsReader)
         {
+            if (settingsReader == null)
+            {
+                throw new ArgumentNullException(nameof(settingsReader));
+            }
+
+            this._settingsReader = settingsReader;
         }
 
         public override void Load()
         {
-            var builder = new ConfigurationBuilder();
-            builder.AddEnvironmentVariables(VCAP_PREFIX);
-            var vcap = builder.Build();
-            Process(vcap);
+            this.Process();
         }
 
-        private void Process(IConfigurationRoot vcap)
+        private void Process()
         {
-            string appJson = vcap[APPLICATION];
+            string appJson = this._settingsReader.ApplicationJson;
             if (!string.IsNullOrEmpty(appJson))
             {
 
@@ -76,7 +71,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
                 }
             }
 
-            string appServicesJson = vcap[SERVICES];
+            string appServicesJson = this._settingsReader.ServicesJson;
             if (!string.IsNullOrEmpty(appServicesJson))
             {
                 var memStream = GetMemoryStream(appServicesJson);
@@ -96,21 +91,21 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
         {
             if (!Data.ContainsKey("vcap:application:instance_id"))
             {
-                Data["vcap:application:instance_id"] = Environment.GetEnvironmentVariable(CF_INSTANCE_GUID);
+                Data["vcap:application:instance_id"] = this._settingsReader.InstanceId;
             }
 
             if (!Data.ContainsKey("vcap:application:instance_index"))
             {
-                Data["vcap:application:instance_index"] = Environment.GetEnvironmentVariable(CF_INSTANCE_INDEX);
+                Data["vcap:application:instance_index"] = this._settingsReader.InstanceIndex;
             }
 
             if (!Data.ContainsKey("vcap:application:port"))
             {
-                Data["vcap:application:port"] = Environment.GetEnvironmentVariable(CF_INSTANCE_PORT);
+                Data["vcap:application:port"] = this._settingsReader.InstancePort;
             }
 
-            Data["vcap:application:instance_ip"] = Environment.GetEnvironmentVariable(CF_INSTANCE_IP);
-            Data["vcap:application:internal_ip"] = Environment.GetEnvironmentVariable(CF_INSTANCE_INTERNAL_IP);
+            Data["vcap:application:instance_ip"] = this._settingsReader.InstanceIp;
+            Data["vcap:application:internal_ip"] = this._settingsReader.InstanceInternalIp;
 
         }
         internal IDictionary<string, string> Properties

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationSource.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationSource.cs
@@ -22,9 +22,11 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
 {
     public class CloudFoundryConfigurationSource : IConfigurationSource
     {
+        public ICloudFoundrySettingsReader SettingsReader { get; set; }
+
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new CloudFoundryConfigurationProvider(new CloudFoundryEnvironmentSettingsReader());
+            return new CloudFoundryConfigurationProvider(this.SettingsReader ?? new CloudFoundryEnvironmentSettingsReader());
         }
     }
 }

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationSource.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationSource.cs
@@ -14,23 +14,17 @@
 // limitations under the License.
 //
 
-using Microsoft.Extensions.Configuration;
-using Steeltoe.Extensions.Configuration.CloudFoundry;
 using System;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
 
-namespace Steeltoe.Extensions.Configuration
+namespace Steeltoe.Extensions.Configuration.CloudFoundry
 {
-    public static class CloudFoundryConfigurationBuilderExtensions
+    public class CloudFoundryConfigurationSource : IConfigurationSource
     {
-        public static IConfigurationBuilder AddCloudFoundry(this IConfigurationBuilder configurationBuilder)
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            if (configurationBuilder == null)
-            {
-                throw new ArgumentNullException(nameof(configurationBuilder));
-            }
-
-            configurationBuilder.Add(new CloudFoundryConfigurationSource());
-            return configurationBuilder;
+            return new CloudFoundryConfigurationProvider();
         }
     }
 }

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationSource.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryConfigurationSource.cs
@@ -24,7 +24,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
     {
         public IConfigurationProvider Build(IConfigurationBuilder builder)
         {
-            return new CloudFoundryConfigurationProvider();
+            return new CloudFoundryConfigurationProvider(new CloudFoundryEnvironmentSettingsReader());
         }
     }
 }

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryEnvironmentSettingsReader.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryEnvironmentSettingsReader.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Linq;
+
+namespace Steeltoe.Extensions.Configuration.CloudFoundry
+{
+    public class CloudFoundryEnvironmentSettingsReader : ICloudFoundrySettingsReader
+    {
+        private const string CF_INSTANCE_GUID = "CF_INSTANCE_GUID";
+
+        private const string CF_INSTANCE_INDEX = "CF_INSTANCE_INDEX";
+
+        private const string CF_INSTANCE_INTERNAL_IP = "CF_INSTANCE_INTERNAL_IP";
+
+        private const string CF_INSTANCE_IP = "CF_INSTANCE_IP";
+
+        private const string CF_INSTANCE_PORT = "CF_INSTANCE_PORT";
+
+        private const string VCAP_APPLICATION = "VCAP_APPLICATION";
+
+        private const string VCAP_SERVICES = "VCAP_SERVICES";
+
+        public string ApplicationJson => Environment.GetEnvironmentVariable(VCAP_APPLICATION);
+
+        public string InstanceId => Environment.GetEnvironmentVariable(CF_INSTANCE_GUID);
+
+        public string InstanceIndex => Environment.GetEnvironmentVariable(CF_INSTANCE_INDEX);
+
+        public string InstanceInternalIp => Environment.GetEnvironmentVariable(CF_INSTANCE_INTERNAL_IP);
+
+        public string InstanceIp => Environment.GetEnvironmentVariable(CF_INSTANCE_IP);
+
+        public string InstancePort => Environment.GetEnvironmentVariable(CF_INSTANCE_PORT);
+
+        public string ServicesJson => Environment.GetEnvironmentVariable(VCAP_SERVICES);
+    }
+}

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryMemorySettingsReader.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/CloudFoundryMemorySettingsReader.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+
+namespace Steeltoe.Extensions.Configuration.CloudFoundry
+{
+    public class CloudFoundryMemorySettingsReader : ICloudFoundrySettingsReader
+    {
+        public string ApplicationJson { get; set; }
+
+        public string InstanceId { get; set; }
+
+        public string InstanceIndex { get; set; }
+
+        public string InstanceInternalIp { get; set; }
+
+        public string InstanceIp { get; set; }
+
+        public string InstancePort { get; set; }
+
+        public string ServicesJson { get; set; }
+    }
+}

--- a/src/Steeltoe.Extensions.Configuration.CloudFoundry/ICloudFoundrySettingsReader.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundry/ICloudFoundrySettingsReader.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+
+namespace Steeltoe.Extensions.Configuration.CloudFoundry
+{
+    public interface ICloudFoundrySettingsReader
+    {
+        string ApplicationJson { get; }
+
+        string InstanceId { get; }
+
+        string InstanceIndex { get; }
+
+        string InstanceInternalIp { get; }
+
+        string InstanceIp { get; }
+
+        string InstancePort { get; }
+
+        string ServicesJson { get; }
+    }
+}

--- a/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryConfigurationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryConfigurationBuilderExtensionsTest.cs
@@ -37,6 +37,8 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
             var ex = Assert.Throws<ArgumentNullException>(() => CloudFoundryConfigurationBuilderExtensions.AddCloudFoundry(configurationBuilder));
             Assert.Contains(nameof(configurationBuilder), ex.Message);
 
+            var ex2 = Assert.Throws<ArgumentNullException>(() => CloudFoundryConfigurationBuilderExtensions.AddCloudFoundry(configurationBuilder, null));
+            Assert.Contains(nameof(configurationBuilder), ex2.Message);
         }
 
         [Fact]

--- a/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryConfigurationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryConfigurationBuilderExtensionsTest.cs
@@ -59,5 +59,91 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
             }
             Assert.NotNull(cloudSource);
         }
+
+        [Fact]
+        public void AddCloudFoundry_CanReadSettingsFromMemory()
+        {
+            var reader = new CloudFoundryMemorySettingsReader
+            {
+                ApplicationJson = @"
+{
+ 
+  'application_id': 'fa05c1a9-0fc1-4fbd-bae1-139850dec7a3',
+  'application_name': 'my-app',
+  'application_uris': [
+    'my-app.10.244.0.34.xip.io'
+  ],
+  'application_version': 'fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca',
+  'limits': {
+    'disk': 1024,
+    'fds': 16384,
+    'mem': 256
+  },
+  'name': 'my-app',
+  'space_id': '06450c72-4669-4dc6-8096-45f9777db68a',
+  'space_name': 'my-space',
+  'uris': [
+    'my-app.10.244.0.34.xip.io',
+    'my-app2.10.244.0.34.xip.io'
+  ],
+  'users': null,
+  'version': 'fb8fbcc6-8d58-479e-bcc7-3b4ce5a7f0ca'
+  }",
+                ServicesJson = @"
+{
+  'elephantsql': [
+    {
+      'name': 'elephantsql-c6c60',
+      'label': 'elephantsql',
+      'tags': [
+        'postgres',
+        'postgresql',
+        'relational'
+      ],
+      'plan': 'turtle',
+      'credentials': {
+        'uri': 'postgres://seilbmbd:ABcdEF@babar.elephantsql.com:5432/seilbmbd'
+      }
+    }
+  ],
+  'sendgrid': [
+    {
+      'name': 'mysendgrid',
+      'label': 'sendgrid',
+      'tags': [
+        'smtp'
+      ],
+      'plan': 'free',
+      'credentials': {
+        'hostname': 'smtp.sendgrid.net',
+        'username': 'QvsXMbJ3rK',
+        'password': 'HCHMOYluTv'
+      }
+    }
+  ]
+}",
+                InstanceId = "7c19d892-21c2-496b-a42a-946bbaa0775e",
+                InstanceIndex = "0",
+                InstanceInternalIp = "127.0.0.1",
+                InstanceIp = "10.41.1.1",
+                InstancePort = "8888"
+            };
+
+            var configuration = new ConfigurationBuilder().AddCloudFoundry(reader).Build();
+
+            Assert.Equal("fa05c1a9-0fc1-4fbd-bae1-139850dec7a3", configuration["vcap:application:application_id"]);
+            Assert.Equal("1024", configuration["vcap:application:limits:disk"]);
+            Assert.Equal("my-app.10.244.0.34.xip.io", configuration["vcap:application:uris:0"]);
+            Assert.Equal("my-app2.10.244.0.34.xip.io", configuration["vcap:application:uris:1"]);
+            Assert.Equal("my-app", configuration["spring:application:name"]);
+            Assert.Equal("elephantsql-c6c60", configuration["vcap:services:elephantsql:0:name"]);
+            Assert.Equal("mysendgrid", configuration["vcap:services:sendgrid:0:name"]);
+
+            Assert.Equal("7c19d892-21c2-496b-a42a-946bbaa0775e", configuration["vcap:application:instance_id"]);
+            Assert.Equal("0", configuration["vcap:application:instance_index"]);
+            Assert.Equal("127.0.0.1", configuration["vcap:application:internal_ip"]);
+            Assert.Equal("10.41.1.1", configuration["vcap:application:instance_ip"]);
+            Assert.Equal("8888", configuration["vcap:application:port"]);
+        }
     }
 }

--- a/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryConfigurationBuilderExtensionsTest.cs
+++ b/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudFoundryConfigurationBuilderExtensionsTest.cs
@@ -40,7 +40,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
         }
 
         [Fact]
-        public void AddCloudFoundry_AddsConfigServerProviderToProvidersList()
+        public void AddCloudFoundry_AddsCloudFoundrySourceToSourcesList()
         {
             // Arrange
             var configurationBuilder = new ConfigurationBuilder();
@@ -48,16 +48,14 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
             // Act and Assert
             configurationBuilder.AddCloudFoundry();
 
-            CloudFoundryConfigurationProvider cloudProvider = null;
-            foreach (IConfigurationProvider provider in configurationBuilder.Sources)
+            CloudFoundryConfigurationSource cloudSource = null;
+            foreach (var source in configurationBuilder.Sources)
             {
-                cloudProvider = provider as CloudFoundryConfigurationProvider;
-                if (cloudProvider != null)
+                cloudSource = source as CloudFoundryConfigurationSource;
+                if (cloudSource != null)
                     break;
             }
-            Assert.NotNull(cloudProvider);
-
+            Assert.NotNull(cloudSource);
         }
-
     }
 }

--- a/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudfoundryConfigurationProviderTest.cs
+++ b/test/Steeltoe.Extensions.Configuration.CloudFoundry.Test/CloudfoundryConfigurationProviderTest.cs
@@ -24,8 +24,10 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
 {
     public class CloudFoundryConfigurationProviderTest
     {
-        public CloudFoundryConfigurationProviderTest()
+        [Fact]
+        public void Ctor_NullReader()
         {
+            Assert.Throws<ArgumentNullException>(() => new CloudFoundryConfigurationProvider(null));
         }
 
         [Fact]
@@ -58,7 +60,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
   }";
 
             Environment.SetEnvironmentVariable("VCAP_APPLICATION", environment);
-            var provider = new CloudFoundryConfigurationProvider();
+            var provider = new CloudFoundryConfigurationProvider(new CloudFoundryEnvironmentSettingsReader());
 
             // Act and Assert
             provider.Load();
@@ -110,7 +112,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
 
 
             Environment.SetEnvironmentVariable("VCAP_SERVICES", environment);
-            var provider = new CloudFoundryConfigurationProvider();
+            var provider = new CloudFoundryConfigurationProvider(new CloudFoundryEnvironmentSettingsReader());
 
             // Act and Assert
             provider.Load();
@@ -202,7 +204,7 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry.Test
 }";
 
             Environment.SetEnvironmentVariable("VCAP_SERVICES", environment);
-            var provider = new CloudFoundryConfigurationProvider();
+            var provider = new CloudFoundryConfigurationProvider(new CloudFoundryEnvironmentSettingsReader());
 
             // Act and Assert
             provider.Load();


### PR DESCRIPTION
Resolves #16.

- Split configuration provider implementation from configuration source implementation following the patterns seen in the `Microsoft.Extensions.Configuration` libraries.
- Split the reading of the environment away from the `CloudFoundryConfigurationProvider` into a separate `ICloudFoundrySettingsReader`.
- Implemented default `CloudFoudnryEnvironmentSettingsReader` that grabs the VCAP_* and Diego variables from the environment.
- Implemented in-memory `CloudFoundryMemorySettingsReader` that can be used for testing and/or local development.