### PR TITLE
Provider should use invariant culture instead of current one

### DIFF
--- a/src/Steeltoe.Extensions.Configuration.ConfigServerBase/ConfigServerConfigurationProvider.cs
+++ b/src/Steeltoe.Extensions.Configuration.ConfigServerBase/ConfigServerConfigurationProvider.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using Steeltoe.Common.Http;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -410,7 +411,7 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
 
         protected internal virtual string ConvertValue(object value)
         {
-            return value.ToString();
+            return Convert.ToString(value, CultureInfo.InvariantCulture);
         }
 
         /// <summary>


### PR DESCRIPTION
This is behavior expected by [BehaviorBinder](https://github.com/aspnet/Configuration/blob/d469707ab18eef7ed0002f00175a9ad5b0f36250/src/Config.Binder/ConfigurationBinder.cs) line 512 and how other providers behaves [JsonConfirationProvider](https://github.com/aspnet/Configuration/blob/d469707ab18eef7ed0002f00175a9ad5b0f36250/src/Config.Json/JsonConfigurationFileParser.cs) line 104