### PR TITLE
Use -1 instead of empty/null strings for vcap:application integers #32

### DIFF
--- a/src/Steeltoe.Extensions.Configuration.CloudFoundryBase/CloudFoundryConfigurationProvider.cs
+++ b/src/Steeltoe.Extensions.Configuration.CloudFoundryBase/CloudFoundryConfigurationProvider.cs
@@ -55,17 +55,17 @@ namespace Steeltoe.Extensions.Configuration.CloudFoundry
         {
             if (!Data.ContainsKey("vcap:application:instance_id"))
             {
-                Data["vcap:application:instance_id"] = _settingsReader.InstanceId;
+                Data["vcap:application:instance_id"] = !string.IsNullOrEmpty(_settingsReader.InstanceId) ? _settingsReader.InstanceId : "-1";
             }
 
             if (!Data.ContainsKey("vcap:application:instance_index"))
             {
-                Data["vcap:application:instance_index"] = _settingsReader.InstanceIndex;
+                Data["vcap:application:instance_index"] = !string.IsNullOrEmpty(_settingsReader.InstanceIndex) ? _settingsReader.InstanceIndex : "-1";
             }
 
             if (!Data.ContainsKey("vcap:application:port"))
             {
-                Data["vcap:application:port"] = _settingsReader.InstancePort;
+                Data["vcap:application:port"] = !string.IsNullOrEmpty(_settingsReader.InstancePort) ? _settingsReader.InstancePort : "-1";
             }
 
             Data["vcap:application:instance_ip"] = _settingsReader.InstanceIp;


### PR DESCRIPTION
instance_id, instance_index and port are all treated as integers in Steetoe Connectors. Setting them to -1 will allow Connectors to function when they are not set to normal values (for instance, when run with `cf run-task`)

https://github.com/SteeltoeOSS/Connectors/issues/22
https://github.com/SteeltoeOSS/Connectors/issues/19