### PR TITLE
Specify InvariantCulture for ToString conversion when publishing ConfigServerClientSettings

### DIFF
--- a/src/Steeltoe.Extensions.Configuration.ConfigServerBase/ConfigServerConfigurationProvider.cs
+++ b/src/Steeltoe.Extensions.Configuration.ConfigServerBase/ConfigServerConfigurationProvider.cs
@@ -412,8 +412,9 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
         /// </summary>
         protected internal virtual void AddConfigServerClientSettings()
         {
-            Data["spring:cloud:config:enabled"] = _settings.Enabled.ToString();
-            Data["spring:cloud:config:failFast"] = _settings.FailFast.ToString();
+            CultureInfo culture = CultureInfo.InvariantCulture;
+            Data["spring:cloud:config:enabled"] = _settings.Enabled.ToString(culture);
+            Data["spring:cloud:config:failFast"] = _settings.FailFast.ToString(culture);
             Data["spring:cloud:config:env"] = _settings.Environment;
             Data["spring:cloud:config:label"] = _settings.Label;
             Data["spring:cloud:config:name"] = _settings.Name;
@@ -421,25 +422,25 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer
             Data["spring:cloud:config:uri"] = _settings.Uri;
             Data["spring:cloud:config:username"] = _settings.Username;
             Data["spring:cloud:config:token"] = _settings.Token;
-            Data["spring:cloud:config:timeout"] = _settings.Timeout.ToString();
-            Data["spring:cloud:config:validate_certificates"] = _settings.ValidateCertificates.ToString();
-            Data["spring:cloud:config:retry:enabled"] = _settings.RetryEnabled.ToString();
-            Data["spring:cloud:config:retry:maxAttempts"] = _settings.RetryAttempts.ToString();
-            Data["spring:cloud:config:retry:initialInterval"] = _settings.RetryInitialInterval.ToString();
-            Data["spring:cloud:config:retry:maxInterval"] = _settings.RetryMaxInterval.ToString();
-            Data["spring:cloud:config:retry:multiplier"] = _settings.RetryMultiplier.ToString();
+            Data["spring:cloud:config:timeout"] = _settings.Timeout.ToString(culture);
+            Data["spring:cloud:config:validate_certificates"] = _settings.ValidateCertificates.ToString(culture);
+            Data["spring:cloud:config:retry:enabled"] = _settings.RetryEnabled.ToString(culture);
+            Data["spring:cloud:config:retry:maxAttempts"] = _settings.RetryAttempts.ToString(culture);
+            Data["spring:cloud:config:retry:initialInterval"] = _settings.RetryInitialInterval.ToString(culture);
+            Data["spring:cloud:config:retry:maxInterval"] = _settings.RetryMaxInterval.ToString(culture);
+            Data["spring:cloud:config:retry:multiplier"] = _settings.RetryMultiplier.ToString(culture);
 
             Data["spring:cloud:config:access_token_uri"] = _settings.AccessTokenUri;
             Data["spring:cloud:config:client_secret"] = _settings.ClientSecret;
             Data["spring:cloud:config:client_id"] = _settings.ClientId;
-            Data["spring:cloud:config:tokenTtl"] = _settings.TokenTtl.ToString();
-            Data["spring:cloud:config:tokenRenewRate"] = _settings.TokenRenewRate.ToString();
+            Data["spring:cloud:config:tokenTtl"] = _settings.TokenTtl.ToString(culture);
+            Data["spring:cloud:config:tokenRenewRate"] = _settings.TokenRenewRate.ToString(culture);
 
-            Data["spring:cloud:config:discovery:enabled"] = _settings.DiscoveryEnabled.ToString();
-            Data["spring:cloud:config:discovery:serviceId"] = _settings.DiscoveryServiceId.ToString();
+            Data["spring:cloud:config:discovery:enabled"] = _settings.DiscoveryEnabled.ToString(culture);
+            Data["spring:cloud:config:discovery:serviceId"] = _settings.DiscoveryServiceId;
 
-            Data["spring:cloud:config:health:enabled"] = _settings.HealthEnabled.ToString();
-            Data["spring:cloud:config:health:timeToLive"] = _settings.HealthTimeToLive.ToString();
+            Data["spring:cloud:config:health:enabled"] = _settings.HealthEnabled.ToString(culture);
+            Data["spring:cloud:config:health:timeToLive"] = _settings.HealthTimeToLive.ToString(culture);
         }
 
         protected internal async Task<ConfigEnvironment> RemoteLoadAsync(string[] requestUris, string label)

--- a/test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
+++ b/test/Steeltoe.Extensions.Configuration.ConfigServerBase.Test/ConfigServerConfigurationProviderTest.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Logging;
 using Steeltoe.Common.Discovery;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Net.Http;
 using Xunit;
@@ -793,50 +794,68 @@ namespace Steeltoe.Extensions.Configuration.ConfigServer.Test
                 ValidateCertificates = false,
                 Token = "vaulttoken",
                 TokenRenewRate = 1,
-                TokenTtl = 2
+                TokenTtl = 2,
+                RetryMultiplier = 1.1
             };
             ConfigServerConfigurationProvider provider = new ConfigServerConfigurationProvider(settings);
+            CultureInfo initialCulture = GetAndSetCurrentCulture(new CultureInfo("ru-RU"));
 
-            // Act and Assert
-            provider.AddConfigServerClientSettings();
+            try
+            {
+                // Act and Assert
+                provider.AddConfigServerClientSettings();
 
-            Assert.True(provider.TryGet("spring:cloud:config:access_token_uri", out string value));
-            Assert.Equal("http://foo.bar/", value);
-            Assert.True(provider.TryGet("spring:cloud:config:client_id", out value));
-            Assert.Equal("client_id", value);
-            Assert.True(provider.TryGet("spring:cloud:config:client_secret", out value));
-            Assert.Equal("client_secret", value);
-            Assert.True(provider.TryGet("spring:cloud:config:env", out value));
-            Assert.Equal("environment", value);
-            Assert.True(provider.TryGet("spring:cloud:config:label", out value));
-            Assert.Equal("label", value);
-            Assert.True(provider.TryGet("spring:cloud:config:name", out value));
-            Assert.Equal("name", value);
-            Assert.True(provider.TryGet("spring:cloud:config:password", out value));
-            Assert.Equal("password", value);
-            Assert.True(provider.TryGet("spring:cloud:config:uri", out value));
-            Assert.Equal("http://foo.bar/", value);
-            Assert.True(provider.TryGet("spring:cloud:config:username", out value));
-            Assert.Equal("username", value);
+                Assert.True(provider.TryGet("spring:cloud:config:access_token_uri", out string value));
+                Assert.Equal("http://foo.bar/", value);
+                Assert.True(provider.TryGet("spring:cloud:config:client_id", out value));
+                Assert.Equal("client_id", value);
+                Assert.True(provider.TryGet("spring:cloud:config:client_secret", out value));
+                Assert.Equal("client_secret", value);
+                Assert.True(provider.TryGet("spring:cloud:config:env", out value));
+                Assert.Equal("environment", value);
+                Assert.True(provider.TryGet("spring:cloud:config:label", out value));
+                Assert.Equal("label", value);
+                Assert.True(provider.TryGet("spring:cloud:config:name", out value));
+                Assert.Equal("name", value);
+                Assert.True(provider.TryGet("spring:cloud:config:password", out value));
+                Assert.Equal("password", value);
+                Assert.True(provider.TryGet("spring:cloud:config:uri", out value));
+                Assert.Equal("http://foo.bar/", value);
+                Assert.True(provider.TryGet("spring:cloud:config:username", out value));
+                Assert.Equal("username", value);
 
-            Assert.True(provider.TryGet("spring:cloud:config:enabled", out value));
-            Assert.Equal("True", value);
-            Assert.True(provider.TryGet("spring:cloud:config:failFast", out value));
-            Assert.Equal("False", value);
-            Assert.True(provider.TryGet("spring:cloud:config:validate_certificates", out value));
-            Assert.Equal("False", value);
-            Assert.True(provider.TryGet("spring:cloud:config:token", out value));
-            Assert.Equal("vaulttoken", value);
-            Assert.True(provider.TryGet("spring:cloud:config:timeout", out value));
-            Assert.Equal("6000", value);
-            Assert.True(provider.TryGet("spring:cloud:config:tokenRenewRate", out value));
-            Assert.Equal("1", value);
-            Assert.True(provider.TryGet("spring:cloud:config:tokenTtl", out value));
-            Assert.Equal("2", value);
-            Assert.True(provider.TryGet("spring:cloud:config:discovery:enabled", out value));
-            Assert.Equal("False", value);
-            Assert.True(provider.TryGet("spring:cloud:config:discovery:serviceId", out value));
-            Assert.Equal(ConfigServerClientSettings.DEFAULT_CONFIGSERVER_SERVICEID, value);
+                Assert.True(provider.TryGet("spring:cloud:config:enabled", out value));
+                Assert.Equal("True", value);
+                Assert.True(provider.TryGet("spring:cloud:config:failFast", out value));
+                Assert.Equal("False", value);
+                Assert.True(provider.TryGet("spring:cloud:config:validate_certificates", out value));
+                Assert.Equal("False", value);
+                Assert.True(provider.TryGet("spring:cloud:config:token", out value));
+                Assert.Equal("vaulttoken", value);
+                Assert.True(provider.TryGet("spring:cloud:config:timeout", out value));
+                Assert.Equal("6000", value);
+                Assert.True(provider.TryGet("spring:cloud:config:tokenRenewRate", out value));
+                Assert.Equal("1", value);
+                Assert.True(provider.TryGet("spring:cloud:config:tokenTtl", out value));
+                Assert.Equal("2", value);
+                Assert.True(provider.TryGet("spring:cloud:config:discovery:enabled", out value));
+                Assert.Equal("False", value);
+                Assert.True(provider.TryGet("spring:cloud:config:discovery:serviceId", out value));
+                Assert.Equal(ConfigServerClientSettings.DEFAULT_CONFIGSERVER_SERVICEID, value);
+                Assert.True(provider.TryGet("spring:cloud:config:retry:multiplier", out value));
+                Assert.Equal("1.1", value);
+            }
+            finally
+            {
+                GetAndSetCurrentCulture(initialCulture);
+            }
+        }
+        
+        private static CultureInfo GetAndSetCurrentCulture(CultureInfo newCulture)
+        {
+            var oldCulture = CultureInfo.DefaultThreadCurrentCulture;
+            CultureInfo.DefaultThreadCurrentCulture = newCulture;
+            return oldCulture;
         }
 
         [Fact]


### PR DESCRIPTION
Missing InvariantCulture specification in ToString makes ConfigServerClientSettings properties unreadable in some cultures 